### PR TITLE
[준] Modify: when chat updated scrollBy => scrollIntoView

### DIFF
--- a/pages/chat/[ROOM_ID].tsx
+++ b/pages/chat/[ROOM_ID].tsx
@@ -17,7 +17,7 @@ function Chat() {
   const [value, setValue] = useState<string>('');
   const router = useRouter();
   const { ROOM_ID } = router.query;
-  const chatPane = useRef(null);
+  const chatEndRef = useRef(null);
 
   const [getRoom, { data }] = useLazyQuery(GET_ROOM);
   const { enterRoom, sendMessage, received, isSocketConnected } = useWebsocket();
@@ -37,7 +37,7 @@ function Chat() {
   }, [ROOM_ID, isSocketConnected]);
 
   useEffect(() => {
-    chatPane.current?.scrollBy({ behavior: 'smooth', top: chatPane.current?.offsetHeight });
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [data]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
@@ -76,7 +76,7 @@ function Chat() {
         <title>채팅</title>
       </Head>
       <NavigationBar title={data?.room.title} />
-      <div className="h-5/6 overflow-auto bg-gray-100" ref={chatPane}>
+      <div className="h-5/6 overflow-auto bg-gray-100">
         {data?.room.chats.map(chat => (
           <Chatlog
             key={chat.id}
@@ -85,6 +85,7 @@ function Chat() {
             created_at={dayjs(chat.created_at).format('h:mm A')}
           />
         ))}
+        <div ref={chatEndRef} />
       </div>
       <form className="sticky bottom-3" onSubmit={handleSubmit}>
         <TextField

--- a/pages/list/index.tsx
+++ b/pages/list/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import CreateRoomModal from 'components/CreateRoomModal';
-import { useQuery, useApolloClient } from '@apollo/client';
-import { GET_ROOMS, GET_ROOM } from 'apollo/queries';
+import { useQuery } from '@apollo/client';
+import { GET_ROOMS } from 'apollo/queries';
 import RoomLog from 'components/RoomLog';
 import { IRoomLog } from 'types';
 import { useWebsocket } from 'hooks/useWebsocket';


### PR DESCRIPTION
- 채팅방에 들어올 때 data 가 변화되는 것을 useEffect 훅으로 감지해서 
가장 하단에 있는 reference 에 대해서 **scrollIntoView({ behavior: 'smooth'})** 를 적용함 

**pages/chat**
```ts

  useEffect(() => {
    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
  }, [data]);

...
      <div className="h-5/6 overflow-auto bg-gray-100">
        {data?.room.chats.map(chat => (
          <Chatlog
            key={chat.id}
            isSender={chat.isSender}
            content={chat.content}
            created_at={dayjs(chat.created_at).format('h:mm A')}
          />
        ))}
        <div ref={chatEndRef} /> // 항상 채팅 데이터의 하단에 있도록 내용이 없는 div 태그 생성 
      </div>
...
```