### PR TITLE
[준] 소켓을 통해 새로운 메세지 올 때 토스트 알림 띄우기

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "10.0.7",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-toastify": "^7.0.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,8 @@ import Template from 'components/template';
 import theme from 'styles/theme';
 import { useApollo } from 'apollo/apolloClient';
 import 'styles/tailwind.css';
+import 'react-toastify/dist/ReactToastify.css';
+import { ToastContainer } from 'react-toastify';
 
 declare global {
   interface Window {
@@ -51,6 +53,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           <ThemeProvider theme={theme}>
             <CssBaseline />
             <Component {...pageProps} />
+            <ToastContainer />
           </ThemeProvider>
         </ApolloProvider>
       </Template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,7 +872,7 @@ classnames@2.2.6:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
-clsx@^1.0.4:
+clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -3026,6 +3026,13 @@ react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-toastify@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.3.tgz#93804c777ecf918872ba3b5be9c654db14547f85"
+  integrity sha512-cxZ5rfurC8LzcZQMTYc8RHIkQTs+BFur18Pzk6Loz6uS8OXUWm6nXVlH/wqglz4Z7UAE8xxcF5mRjfE13487uQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^4.4.0:
   version "4.4.1"


### PR DESCRIPTION
## 변경사항

### react-toastify 패키지 추가
- [react-toastify](https://fkhadra.github.io/react-toastify/introduction/)

### useChatReceived 
- 현재 채팅방이 아닐 때 => 토스트 띄움 
- 현재 채팅방이지만 같은 아이디를 가진 방이 아닐 때 => 토스트 띄움
- 토스트 클릭 할 시에 메세지가 온 방으로 `router push`
```ts
...
    const isCurrentRoom = router.query.hasOwnProperty('ROOM_ID');
    const isTheSameRoom = router.query['ROOM_ID'] === ROOM_ID;

    if (isCurrentRoom && isTheSameRoom) return;

    toast(`💌 ${message}`, {
      position: 'top-center',
      autoClose: 3000,
      hideProgressBar: false,
      closeOnClick: true,
      pauseOnHover: true,
      onClick: () => router.push(`${isCurrentRoom ? '' : '/chat/'}${ROOM_ID}`),
...
```