### PR TITLE
[준] Modify: 새로운 채팅이 왔을 때, list 페이지에서 rooms 배열 소팅하기

### DIFF
--- a/pages/list/index.tsx
+++ b/pages/list/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
-import { useQuery, useReactiveVar, gql, useMutation } from '@apollo/client';
-import { GET_ROOMS, GET_ROOM } from 'apollo/queries';
+import { useQuery, useReactiveVar } from '@apollo/client';
+import { GET_ROOMS } from 'apollo/queries';
 import { authVar } from 'apollo/store';
 import RoomLog from 'components/RoomLog';
 import { IRoomLog } from 'types';
@@ -10,9 +10,9 @@ import { useChatReceived } from 'hooks/useChatReceived';
 import NavigationBar from 'components/NavigationBar';
 const CreateRoomModal = dynamic(() => import('components/CreateRoomModal'));
 
-function RoomList(props) {
+function RoomList() {
   const [isCreateModalOn, setIsCreateModalOn] = useState<boolean>(false);
-  const { data, loading, error } = useQuery(GET_ROOMS);
+  const { data, loading } = useQuery(GET_ROOMS);
   const { received, enterRoom, isSocketConnected } = useWebsocket();
   useChatReceived(received);
   const _authVar = useReactiveVar(authVar);
@@ -29,20 +29,27 @@ function RoomList(props) {
     <>
       <div className="h-screen transform divide-y-2">
         <NavigationBar title={'채팅'} />
-        {data?.rooms.map((room: IRoomLog) => (
-          <RoomLog
-            key={room.id}
-            roomStatus={room.roomStatus}
-            recentChat={room.recentChat}
-            lastViewedChat={room.lastViewedChat}
-            title={room.title}
-            location={room.location}
-            id={room.id}
-            myId={_authVar.userId}
-            receiver={room.receiver}
-            inviter={room.inviter}
-          />
-        ))}
+        {data &&
+          [...data.rooms]
+            .sort((a, b) => {
+              if (a.recentChat?.created_at < b.recentChat?.created_at) return 1;
+              if (a.recentChat?.created_at > b.recentChat?.created_at) return -1;
+              return 0;
+            })
+            .map((room: IRoomLog) => (
+              <RoomLog
+                key={room.id}
+                roomStatus={room.roomStatus}
+                recentChat={room.recentChat}
+                lastViewedChat={room.lastViewedChat}
+                title={room.title}
+                location={room.location}
+                id={room.id}
+                myId={_authVar.userId}
+                receiver={room.receiver}
+                inviter={room.inviter}
+              />
+            ))}
       </div>
       {isCreateModalOn ? (
         <CreateRoomModal type="list" setIsCreateModalOn={setIsCreateModalOn} />


### PR DESCRIPTION
- 테스팅 해 본 결과 새로운 메세지가 와서 recentChat 이 업데이트 되면 캐쉬가 업데이트 된다.
- 즉, GET_ROOMS 쿼리로 가져오는 data 에 변화가 생겨서 list 페이지를 새롭게 렌더링 함 
- 이 점을 이용해서 새롭게 바뀐 데이터에 대해서 cache 를 업데이트 하는 복잡한 로직보다 `recentChat.created_at` 필드를 기준으로
정렬한 배열을 렌더링 하는 것이 좋다고 판단 함

### pages/list/index.tsx
```ts
  const { data, loading } = useQuery(GET_ROOMS); // 새로 메세지가 올 때마다 변화를 감지해서 rooms list 페이지 re-render

...
        {data &&
          [...data.rooms]
            .sort((a, b) => {
              if (a.recentChat?.created_at < b.recentChat?.created_at) return 1;
              if (a.recentChat?.created_at > b.recentChat?.created_at) return -1;
              return 0;
            })
```