### PR TITLE
[준] Add: useClipboard 훅 | 방 생성 프로세스 변경 

### DIFF
--- a/components/LoginForm/index.tsx
+++ b/components/LoginForm/index.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useLazyQuery, useReactiveVar, useMutation, gql } from '@apollo/client';
 import { GOOGLE_LOGIN } from 'apollo/queries';
 import { invitedRoomIdVar, authVar } from 'apollo/store';
 import { useSaveReceiver } from 'apollo/mutations/saveReceiver';
+import { useClipboard } from 'hooks/useClipboard';
 
 function Login() {
   const _invitedRoomIdVar = useReactiveVar(invitedRoomIdVar);
@@ -15,15 +16,15 @@ function Login() {
   const router = useRouter();
   const { saveReceiver } = useSaveReceiver();
 
-  const handleKakaoLogin = () => {
-    const { Kakao } = window;
-    Kakao.Auth.login({
-      success: res => {
-        console.log(res);
-      },
-      fail: console.log,
-    });
-  };
+  // const handleKakaoLogin = () => {
+  //   const { Kakao } = window;
+  //   Kakao.Auth.login({
+  //     success: res => {
+  //       console.log(res);
+  //     },
+  //     fail: console.log,
+  //   });
+  // };
 
   // google Login setting
   useEffect(() => {

--- a/hooks/useClipboard.ts
+++ b/hooks/useClipboard.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { toast } from 'react-toastify';
+
+export const useClipboard = (
+  setIsCreateModalOn?: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  const [ROOM_ID, setRoomId] = useState<string>('');
+
+  const copyToClipBoard = (ROOM_ID: string | undefined) => {
+    setRoomId(ROOM_ID);
+  };
+
+  useEffect(() => {
+    if (!ROOM_ID) return;
+
+    navigator.clipboard
+      .writeText(`${window.location.origin}/invitation?ROOM_ID=${ROOM_ID}`)
+      .then(() => {
+        console.log('copy completed');
+      }, console.log);
+
+    toast.info(`초대 링크가 클립보드에 복사되었습니다`, {
+      position: 'bottom-center',
+      autoClose: 2500,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: false,
+    });
+
+    setRoomId('');
+
+    if (!setIsCreateModalOn) return;
+    setIsCreateModalOn(false);
+  }, [ROOM_ID]);
+
+  return { copyToClipBoard };
+};


### PR DESCRIPTION
## useClipboard
- setIsCreateModalOn 을 optional 로 지정해서 재사용할 수 있도록 훅으로 로직 분리함
- createRoomModal 창에서는 클립보드에 복사되면 모달을 끄고
- 후에 채팅방에서는 useClipboard 훅을 사용할 때, 인자로 아무것도 전달 해 주지 않아도 클립보드에 링크가 복사될 수 있도록 함
```ts
import { useState, useEffect } from 'react';
import { toast } from 'react-toastify';

export const useClipboard = (
  setIsCreateModalOn?: React.Dispatch<React.SetStateAction<boolean>>,
) => {
  const [ROOM_ID, setRoomId] = useState<string>('');

  const copyToClipBoard = (ROOM_ID: string | undefined) => {
    setRoomId(ROOM_ID);
  };

  useEffect(() => {
    if (!ROOM_ID) return;

    navigator.clipboard
      .writeText(`${window.location.origin}/invitation?ROOM_ID=${ROOM_ID}`)
      .then(() => {
        console.log('copy completed');
      }, console.log);

    toast.info(`초대 링크가 클립보드에 복사되었습니다`, {
      position: 'bottom-center',
      autoClose: 2500,
      hideProgressBar: false,
      closeOnClick: true,
      pauseOnHover: false,
    });

    setRoomId('');

    if (!setIsCreateModalOn) return;
    setIsCreateModalOn(false);
  }, [ROOM_ID]);

  return { copyToClipBoard };
};

```

## createRoomModal 에서 방 생성 후 프로세스 변경 
- 방방을 생성하고 createRoom mutation 후 응답으로 받은 방의 정보가 생성되었을 때
- 모든 input 창 disabled 하고, map 에 걸려있던 이벤트도 종료함. 
- 초대링크 복사하기 버튼으로 프로세스가 넘어가서 유저가 클립보드에 링크를 복사할 수 있도록 함

### 변경이유
- [iOS 사파리 clipboard 보안이슈](https://webkit.org/blog/10855/async-clipboard-api/)
- **유저의 이벤트가 없을 시에는 navigator.clipboard 가 활성화 되지 않음**

<img width="498" alt="Screen Shot 2021-04-11 at 6 16 22 PM" src="https://user-images.githubusercontent.com/63147802/114298580-116c3780-9af2-11eb-9d2c-937ce2c33221.png">
