### PR TITLE
[준] Add: useMarker

### DIFF
--- a/apollo/mutations/updateRoom.ts
+++ b/apollo/mutations/updateRoom.ts
@@ -27,7 +27,7 @@ export const useUpdateRoom = (ROOM_ID: string) => {
 
       const existingRoom = cache.readQuery({
         query: GET_ROOM,
-        variables: { room_id: ROOM_ID },
+        variables: { room_id: ROOM_ID, offset: 0, limit: 10 },
       }) as { room: { chats: string[] } };
 
       cache.writeQuery({

--- a/components/Map/index.tsx
+++ b/components/Map/index.tsx
@@ -8,7 +8,7 @@ import ProgressBar from 'components/ProgressBar';
 import { ICoords } from 'types';
 
 interface IMap {
-  loading: boolean;
+  isMapLoading: boolean;
   title: string;
   minuteLeft: number;
   currentLocation: ICoords;
@@ -16,7 +16,14 @@ interface IMap {
   distanceProgress: [number, number];
 }
 
-function Map({ loading, title, minuteLeft, currentLocation, received, distanceProgress }: IMap) {
+function Map({
+  isMapLoading,
+  title,
+  minuteLeft,
+  currentLocation,
+  received,
+  distanceProgress,
+}: IMap) {
   return (
     <div className="relative flex flex-col justify-between h-screen overflow-hidden">
       <Head>
@@ -38,7 +45,7 @@ function Map({ loading, title, minuteLeft, currentLocation, received, distancePr
       </div>
       <div className="relative flex flex-col flex-grow">
         <div id="map" className="flex-grow z-0"></div>
-        {loading && <Skeleton />}
+        {isMapLoading && <Skeleton />}
       </div>
       {currentLocation && received && (
         <div className="sticky bottom-0 bg-white z-10">

--- a/hooks/useClipboard.ts
+++ b/hooks/useClipboard.ts
@@ -1,13 +1,13 @@
 import React, { useRef } from 'react';
 
-interface handleClipboardInput {
+interface useClipBoardInput {
   defaultContent: string;
   onSucceed: () => void;
   onFailed: () => void;
 }
 
 type TUseClipBoard = (
-  input: handleClipboardInput,
+  input: useClipBoardInput,
 ) => {
   handleClipboard: (e: React.MouseEvent) => void;
   setCopyContent: (content: string) => void;
@@ -17,7 +17,7 @@ export const useClipboard: TUseClipBoard = ({
   onSucceed,
   onFailed,
   defaultContent,
-}: handleClipboardInput) => {
+}: useClipBoardInput) => {
   const contentRef = useRef<string>('');
   const setCopyContent = (content: string) => {
     contentRef.current = content;

--- a/hooks/useMarker.ts
+++ b/hooks/useMarker.ts
@@ -1,33 +1,46 @@
-import { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { ICoords } from 'types';
-import { useNavermap } from 'hooks/useNavermap';
 
-interface Position {
-  type?: string;
-  markerRef?: React.MutableRefObject<any>;
-  reserved_location?: ICoords;
+interface useMarkerInput {
+  map: any;
+  setLocation: React.Dispatch<React.SetStateAction<ICoords>>;
+  setAddress: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export const useMarker = ({ type, markerRef, reserved_location }: Position) => {
-  const { map, loading } = useNavermap(null);
-  const [location, setLocation] = useState<ICoords>();
-  const [markedAddress, setMarkedAddress] = useState<string>('');
+interface IMarkerInput {
+  x: number;
+  y: number;
+  _lat: number; // y
+  _lng: number; // x
+}
 
-  const { naver } = window as any;
-  useEffect(() => {
-    //좌표 보내줄 때
-    if (location) {
-      new naver.maps.Marker({
-        position: new naver.maps.LatLng(reserved_location.latitude, reserved_location.longitude),
+type TUseMarker = (
+  input: useMarkerInput,
+) => {
+  handleMapClick: (e: React.MouseEvent) => void;
+  setMarkerPosition: (coord: IMarkerInput) => void;
+};
+
+export const useMarker: TUseMarker = ({ map, setLocation, setAddress }) => {
+  const markerRef = useRef(null);
+  const { naver } = window;
+
+  const setMarkerPosition = (coord: IMarkerInput) => {
+    if (!markerRef.current) {
+      markerRef.current = new naver.maps.Marker({
+        position: new naver.maps.LatLng(coord._lat, coord._lng),
         map,
       });
       return;
     }
-  }, []);
+
+    markerRef.current.setPosition(coord);
+  };
 
   const handleMapClick = useCallback(
     (e: any) => {
-      const { naver } = window;
+      if (!map) return;
+
       const { _lat: latitude, _lng: longitude } = e.coord;
       setLocation({ latitude, longitude });
       setMarkerPosition(e.coord);
@@ -37,24 +50,12 @@ export const useMarker = ({ type, markerRef, reserved_location }: Position) => {
         },
         (status: any, response: any) => {
           if (status === naver.maps.Service.Status.ERROR) return console.log(status);
-          setMarkedAddress(response.v2.address.jibunAddress);
+          setAddress(response.v2.address.jibunAddress);
         },
       );
     },
     [map],
   );
 
-  const setMarkerPosition = (coord: ICoords | { x: number; y: number }) => {
-    const { naver } = window;
-    if (!markerRef?.current) {
-      markerRef.current = new naver.maps.Marker({
-        position: coord,
-        map,
-      });
-      return;
-    }
-    markerRef.current.setPosition(coord);
-  };
-
-  return { markedAddress, handleMapClick, setMarkerPosition };
+  return { handleMapClick, setMarkerPosition };
 };

--- a/hooks/useNavermap.ts
+++ b/hooks/useNavermap.ts
@@ -1,12 +1,18 @@
-import { isNullableType } from 'graphql';
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { ICoords } from 'types';
 // import { useMarker } from 'hooks/useMarker';
 
+type TUseNaverMap = (
+  reserved_location?: ICoords,
+) => {
+  map: any;
+  isMapLoading: boolean;
+};
+
 //사용하실 때 <div id='map' /> 하나 지정해두시면 그 안으로 네이버지도가 쏙 들어갑니다
-export const useNavermap = (reserved_location?: ICoords) => {
+export const useNavermap: TUseNaverMap = (reserved_location?: ICoords) => {
   const [map, setMap] = useState();
-  const [loading, setLoading] = useState<boolean>(true);
+  const [isMapLoading, setLoading] = useState<boolean>(true);
   // const markerRef = useRef(null);
 
   const onGeolocationError = useCallback((error: GeolocationPositionError) => {
@@ -62,5 +68,5 @@ export const useNavermap = (reserved_location?: ICoords) => {
     );
   }, []);
 
-  return { map, loading };
+  return { map, isMapLoading };
 };

--- a/pages/map/[ROOM_ID].tsx
+++ b/pages/map/[ROOM_ID].tsx
@@ -24,7 +24,7 @@ function MapPage() {
   const [isBothConnected, setIsBothConnected] = useState<boolean>(false);
   const [distanceProgress, setDistanceProgress] = useState<[number, number]>([0, 100]);
   const [minuteLeft, setMinuteLeft] = useState<number>(123);
-  const { map, loading } = useNavermap();
+  const { map, isMapLoading } = useNavermap();
   const router = useRouter();
   const { enterRoom, sendMessage, isSocketConnected, received } = useWebsocket();
   const rabbitMarker = useRef(null);
@@ -210,7 +210,7 @@ function MapPage() {
 
   return (
     <Map
-      loading={loading}
+      isMapLoading={isMapLoading}
       title={data?.room?.title}
       minuteLeft={minuteLeft}
       currentLocation={currentLocation}


### PR DESCRIPTION
# useMarker 추가
- 마커를 찍는 로직을 재활용 하기 위해서 커스텀 훅으로 분리 

## TUseMarker
```ts
interface useMarkerInput {
  map: any;
  setLocation: React.Dispatch<React.SetStateAction<ICoords>>;
  setAddress: React.Dispatch<React.SetStateAction<string>>;
}

type TUseMarker = (
  input: useMarkerInput,
) => {
  handleMapClick: (e: React.MouseEvent) => void;
  setMarkerPosition: (coord: IMarkerInput) => void;
};
```

### Input: useMarkerInput 
- map: useNaverMap 훅에서 리턴하는 naver map 객체
- setLocation: ICoords 타입을 가지는 위치정보를 업데이트하는 React setState 함수
- setAddress: 모달에서 화면에 렌더링 할 주소를 업데이트하는 React setState 함수

### Return
- handleMapClick: 지도에 유저의 클릭 이벤트가 발생할 때 실행되는 함수
- setMarkerPosition: 지도 위에 있는 마커(useRef 로 생성한 변수)를 업데이트 하는 함수

## 사용방법
> **CreateRoomModal.ts**
- 아래와 같이 map 객체, setAddress, setLocation 을 인자로 넣고
- 함수를 리턴받아서 필요한 곳에서 사용한다. 
```ts
  const { handleMapClick, setMarkerPosition } = useMarker({ map, setAddress, setLocation });


  useEffect(() => {
    if (!map) return;

    const { naver } = window;
  // map이 로딩되고 handleMapClick 함수를 맵핑해 준다. 
    naver.maps.Event.addListener(map, 'click', handleMapClick); 
  }, [map]);
```

## Next Actions
- 다음 맵 API 로 주소 검색하는 부분도 훅으로 분리하기